### PR TITLE
Is this a typo or is it meant to be this way. 

### DIFF
--- a/src/EssentialsPE/Commands/Override/Gamemode.php
+++ b/src/EssentialsPE/Commands/Override/Gamemode.php
@@ -15,7 +15,7 @@ class Gamemode extends BaseOverrideCommand{
      */
     public function __construct(BaseAPI $api){
         parent::__construct($api, "gamemode", "Change player gamemode", "<mode> [player]", true, ["gma", "gmc", "gms", "gmt", "adventure", "creative", "survival", "spectator", "viewer"]);
-        $this->setPermission("essentials.gamemode.use.*");
+        $this->setPermission("essentials.gamemode.use");
     }
 
     /**


### PR DESCRIPTION
Adding the `.*` after `essentials.command.gamemode` makes it backward incompatible and this was also not changed in plugin.yml so maybe a typo?