### PR TITLE
Fix /vanish command

### DIFF
--- a/src/EssentialsPE/BaseFiles/BaseAPI.php
+++ b/src/EssentialsPE/BaseFiles/BaseAPI.php
@@ -2115,7 +2115,7 @@ class BaseAPI{
      */
     public function setVanish(Player $player, bool $state, bool $noPacket = false): bool{
         if($this->invisibilityEffect === null){
-            $effect = new EffectInstance(Effect::getEffect(Effect::INVISIBILITY) (99999999*20), (1), (false));
+            $effect = new EffectInstance(Effect::getEffect(Effect::INVISIBILITY), 99999999*20, 1, false);
             $this->invisibilityEffect = $effect;
         }
         $this->getServer()->getPluginManager()->callEvent($ev = new PlayerVanishEvent($this, $player, $state, $noPacket));


### PR DESCRIPTION
/vanish used to cause an error.
```
2018-06-19 [01:12:36] [Server thread/CRITICAL]: Unhandled exception executing command 'v' in vanish: Function name must be a string
2018-06-19 [01:12:36] [Server thread/CRITICAL]: Error: "Function name must be a string" (EXCEPTION) in "EssentialsPE_dev-57.phar/src/EssentialsPE/BaseFiles/BaseAPI" at line 2118
2018-06-19 [01:12:36] [Server thread/DEBUG]: #0 EssentialsPE_dev-57.phar/src/EssentialsPE/BaseFiles/BaseAPI(2177): EssentialsPE\BaseFiles\BaseAPI->setVanish(pocketmine\Player object, boolean 1)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #1 EssentialsPE_dev-57.phar/src/EssentialsPE/Commands/Vanish(46): EssentialsPE\BaseFiles\BaseAPI->switchVanish(pocketmine\Player object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #2 src/pocketmine/command/SimpleCommandMap(258): EssentialsPE\Commands\Vanish->execute(pocketmine\Player object, string v, array Array())
2018-06-19 [01:12:36] [Server thread/DEBUG]: #3 src/pocketmine/Server(1946): pocketmine\command\SimpleCommandMap->dispatch(pocketmine\Player object, string v)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #4 src/pocketmine/Player(2190): pocketmine\Server->dispatchCommand(pocketmine\Player object, string v)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #5 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(222): pocketmine\Player->chat(string /v)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #6 src/pocketmine/network/mcpe/protocol/CommandRequestPacket(54): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleCommandRequest(pocketmine\network\mcpe\protocol\CommandRequestPacket object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #7 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(92): pocketmine\network\mcpe\protocol\CommandRequestPacket->handle(pocketmine\network\mcpe\PlayerNetworkSessionAdapter object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #8 src/pocketmine/network/mcpe/protocol/BatchPacket(114): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(pocketmine\network\mcpe\protocol\CommandRequestPacket object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #9 src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(92): pocketmine\network\mcpe\protocol\BatchPacket->handle(pocketmine\network\mcpe\PlayerNetworkSessionAdapter object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #10 src/pocketmine/Player(3038): pocketmine\network\mcpe\PlayerNetworkSessionAdapter->handleDataPacket(pocketmine\network\mcpe\protocol\BatchPacket object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #11 src/pocketmine/network/mcpe/RakLibInterface(153): pocketmine\Player->handleDataPacket(pocketmine\network\mcpe\protocol\BatchPacket object)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #12 vendor/pocketmine/raklib/server/ServerHandler(98): pocketmine\network\mcpe\RakLibInterface->handleEncapsulated(string 35.230.5.112 50043, raklib\protocol\EncapsulatedPacket object, integer 0)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #13 src/pocketmine/network/mcpe/RakLibInterface(96): raklib\server\ServerHandler->handlePacket()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #14 src/pocketmine/network/Network(89): pocketmine\network\mcpe\RakLibInterface->process()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #15 src/pocketmine/Server(2495): pocketmine\network\Network->processInterfaces()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #16 src/pocketmine/Server(2243): pocketmine\Server->tick()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #17 src/pocketmine/Server(2119): pocketmine\Server->tickProcessor()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #18 src/pocketmine/Server(1701): pocketmine\Server->start()
2018-06-19 [01:12:36] [Server thread/DEBUG]: #19 src/pocketmine/PocketMine(305): pocketmine\Server->__construct(BaseClassLoader object, pocketmine\utils\MainLogger object, string /home/minecraft/multicraft/servers/server31414/, string /home/minecraft/multicraft/servers/server31414/plugins/)
2018-06-19 [01:12:36] [Server thread/DEBUG]: #20 /home/minecraft/multicraft/servers/server31414/pmmp_1001_1.4.0.phar(1): require(string phar:///home/minecraft/multicraft/servers/server31414/pmmp_1001_1.4.0.phar/src/pocketmine/PocketMine.php)
```

This PR fixes the /vanish command. It has been tested.

probably resolves #17.